### PR TITLE
More consistent sorting on binary-tree algo

### DIFF
--- a/lib/algorithms/binary-tree.algorithm.js
+++ b/lib/algorithms/binary-tree.algorithm.js
@@ -5,7 +5,14 @@ var binpacking = require('binpacking'),
 function binaryTreePackingAlgorithm(items) {
   // Sort the items by their height
   items.sort(function (a, b) {
-    return b.height - a.height;
+    var diff = b.height - a.height;
+    if(diff === 0) {
+      diff = b.width - a.width;
+    }
+    if(diff === 0 && b.meta._filepath) {
+      diff = (b.meta._filepath > a.meta._filepath);
+    }
+    return diff;
   });
 
   // Rename all `width` and `height`


### PR DESCRIPTION
The images are currently sorted by height only.

This is not a problem for most folks, but once you need to start building retina/regular sprites and share the generated stylesheet between them, the sprites need to be as consistent as they can get.
