### PR TITLE
Switched btree dep to boxpack

### DIFF
--- a/lib/algorithms/binary-tree.algorithm.js
+++ b/lib/algorithms/binary-tree.algorithm.js
@@ -1,6 +1,5 @@
 // Load in our binary packer
-var binpacking = require('binpacking'),
-    GrowingPacker = binpacking.GrowingPacker;
+var boxpack = require('boxpack');
 
 exports.sort = function (items) {
   // Sort the items by their height
@@ -11,30 +10,10 @@ exports.sort = function (items) {
 };
 
 exports.placeItems = function (items) {
-  // Rename all `width` and `height`
-  items.forEach(function (item) {
-    item.h = item.height;
-    item.w = item.width;
-  });
 
-  // Pack the items
-  var packer = new GrowingPacker();
-  packer.fit(items);
-
-  // Remove the `w` and `h` properties
-  items.forEach(function (item) {
-    delete item.h;
-    delete item.w;
-  });
-
-  // Relocate the `x`, `y`, and remove `fit`
-  items.forEach(function (item) {
-    var fit = item.fit;
-    item.x = fit.x;
-    item.y = fit.y;
-    delete item.fit;
-  });
+  // Create packer instance
+  var packer = new boxpack();
 
   // Return the packed items
-  return items;
+  return packer.pack(items);
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "algorithm"
   ],
   "dependencies": {
-    "binpacking": "0.0.1"
+    "boxpack": "0.1.0"
   }
 }


### PR DESCRIPTION
Fixes #6 

Great suggestion on `boxpack`, really easy switch.

All of the iterations for the input and output properties are no longer necessary, the new module doesn't use the naming shortcuts the old one did.

Tests are passing. I also regenerated a handful of my project spritesheets, all were identical through the switch, but please double check before merging, you probably know of a few edge cases?