### PR TITLE
Updates for Travis CI + update dependencies to fix vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
-  - "0.8"
-matrix:
-  allow_failures:
-    - node_js: "0.11"
+  - "16"
+  - "14"
+  - "12"
 
 before_install:
   - curl --location http://rawgit.com/twolfson/fix-travis-ci/master/lib/install.sh | bash -s

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "test": "npm run lint && nodeunit test/"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.13",
-    "grunt-spritesmith": "~2.20.0",
-    "jshint": "~2.5.10",
-    "nodeunit": "~0.9.0"
+    "grunt": "~1.4.0",
+    "grunt-cli": "~1.4.2",
+    "grunt-spritesmith": "~6.9.0",
+    "jshint": "~2.12.0",
+    "nodeunit": "~0.11.3"
   },
   "keywords": [
     "layout",
@@ -44,6 +44,6 @@
     "algorithm"
   ],
   "dependencies": {
-    "bin-pack": "~1.0.1"
+    "bin-pack": "~1.0.2"
   }
 }


### PR DESCRIPTION
These updates fix vulnerabilities in (dev) dependencies.

Note: [nodeunit](https://www.npmjs.com/package/nodeunit), a dev dependency, is unmaintained, and therefore one vulnerability remains. Still better than not updating at all though. :)